### PR TITLE
Minor change : Allow label & button_text to be empty in material_button & material_modal

### DIFF
--- a/R/shiny-material-button.R
+++ b/R/shiny-material-button.R
@@ -14,13 +14,13 @@
 #'   depth = 5,
 #'   color = "blue lighten-2"
 #' )
-material_button <- function(input_id, label, icon = NULL, depth = NULL, color = NULL) {
+material_button <- function(input_id, label = "", icon = NULL, depth = NULL, color = NULL) {
   
   if(!is.null(icon)){
     icon_tag <-
       shiny::HTML(
         paste0(
-          '<i class="material-icons left">',
+          '<i class="material-icons ', if (label != "") "left", '">',
           icon,
           '</i>')
       )

--- a/R/shiny-material-modal.R
+++ b/R/shiny-material-modal.R
@@ -19,13 +19,13 @@
 #'   button_color = "red lighten-3",
 #'   shiny::tags$p("Modal Content")
 #' )
-material_modal <- function(modal_id, button_text, title, ..., button_icon = NULL, floating_button = FALSE, button_depth = NULL, button_color = NULL, close_button_label = "Close", display_button = TRUE){
+material_modal <- function(modal_id, title, ..., button_text = "", button_icon = NULL, floating_button = FALSE, button_depth = NULL, button_color = NULL, close_button_label = "Close", display_button = TRUE){
   
   if(!is.null(button_icon)){
     icon_tag <-
       shiny::HTML(
         paste0(
-          '<i class="material-icons left">',
+          '<i class="material-icons ', if (button_text != "") "left" ,'">',
           button_icon,
           '</i>')
       )


### PR DESCRIPTION
Hi, 

I propose a minor change for function : `material_button` & `material_modal`.

Why :
- It allow empty label for button and modal et It's still beautiful.  ;-)

Changes : 
- `label`, `button_text` are empty string by default

So :
- Icon dont need to be in class left when label is empty
- `button_text` need to be after `...` into the function param. 
  
Regards