### PR TITLE
[Patch] Added a check for names of choices in update_dropdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shinymaterial
 Type: Package
 Title: Implement Material Design in Shiny Applications
-Version: 0.5.3.9000
+Version: 0.5.3.9001
 Authors@R: c(
     person("Eric", "Anderson", role = c("aut", "cre"), email = "eric.ray.anderson@gmail.com"),
     person("Alvin", "Wang", role = c("ctb", "cph"), comment = "Materialize CSS library"),

--- a/R/update-shiny-material-dropdown.R
+++ b/R/update-shiny-material-dropdown.R
@@ -19,9 +19,13 @@ update_material_dropdown <- function(session, input_id, value = NULL, choices = 
     return(NULL)
   }
   
-
   
   if(!is.null(choices)){
+    
+    if ( is.null(names(choices)) ){
+      names(choices) <- choices
+    }
+    
     
     if(!(value %in% choices)) {
       message("ERROR: value '", value, "' not found in choices")


### PR DESCRIPTION
In the current version, update_material_dropdown needs to be passed a named character vector to run. Without any names, the result is just a blank dropdown, which is confusing from the dev point of view.

As these name are mandatory for this to work, this little patch just add an extra check in case of missing names for the choices params.

Here is an example : 

+ Current version : 

This left a blank dropdown 

``` r 
library(shiny)
library(shinymaterial)

ui <- material_page(
  title = "Example Title",
  material_dropdown("dd", "Choices", choices = c("a", "b")),
  material_button("change", "change")
)

server <- function(input, output, session) {

  observeEvent(input$change, {
    v <- sample(letters)

    update_material_dropdown(
      session, 
      "dd", 
      value = v[1], 
      choices = v
    )
  }, ignoreInit = TRUE)
}

shinyApp(ui, server)
```

so we need to : 

``` r 
 observeEvent(input$change, {
    v <- sample(letters)
    names(v) <- v
    update_material_dropdown(
      session, 
      "dd", 
      value = v[1], 
      choices = v
    )
  }, ignoreInit = TRUE)
```

With this patch, the choices will be set even if the character vector passed is unnamed. 

Best, 
Colin 