### PR TITLE
Add divider option for material_card

### DIFF
--- a/R/shiny-material-card.R
+++ b/R/shiny-material-card.R
@@ -4,13 +4,14 @@
 #' @param title String. The title of the card
 #' @param ... The UI elements to place in the card
 #' @param depth Integer. The amount of depth of the card. The value should be between 0 and 5. Leave empty for the default depth.
+#' @param divider logical. Should there be a divider element between card title and card content?
 #' @examples
 #' material_card(
 #'   title = "Example Card",
 #'   depth = 5,
 #'   shiny::tags$h5("Card Content")
 #' )
-material_card <- function(title, ..., depth = NULL){
+material_card <- function(title, ..., depth = NULL, divider = FALSE){
   
   shiny::tags$div(
     class = 
@@ -27,6 +28,17 @@ material_card <- function(title, ..., depth = NULL){
       shiny::tags$span(
         class = "card-title",
         title
+      ),
+      shiny::tags$div(
+        class =
+          paste0(
+            '',
+            ifelse(
+              divider,
+              'divider',
+              ''
+            )
+          )
       ),
       ...
     )


### PR DESCRIPTION
I find myself needing card dividers many times. Small PR to add an additional material_card parameter for a divider between card title and card content. 