### PR TITLE
Add selected choice & option with gap to material_radio_button

### DIFF
--- a/R/shiny-material-radio-button.R
+++ b/R/shiny-material-radio-button.R
@@ -4,7 +4,9 @@
 #' @param input_id String. The input identifier used to access the value.
 #' @param label String. The radio button label.
 #' @param choices Named vector. The option names and underyling values.
+#' @param selected The initially selected value (if not specified then defaults to the first value).
 #' @param color String. The color of the radio buttons. Leave empty for the default color. Visit \url{http://materializecss.com/color.html} for a list of available colors. \emph{This input requires using color hex codes, rather than the word form. E.g., "#ef5350", rather than "red lighten-1".}
+#' @param with_gap Boolean. To create a radio button with a gap.
 #' @examples
 #' material_radio_button(
 #'   input_id = "example_radio_button",
@@ -16,7 +18,7 @@
 #'   ),
 #'   color = "#ef5350"
 #' )
-material_radio_button <- function(input_id, label, choices, color = NULL) {
+material_radio_button <- function(input_id, label, choices, selected = NULL, color = NULL, with_gap = FALSE) {
   
   if(!is.null(color)){
     
@@ -47,28 +49,26 @@ material_radio_button <- function(input_id, label, choices, color = NULL) {
   material_radio_choices <- shiny::tagList()
   
   has_names <- !is.null(names(choices))
+  choices[choices == ""] <- "_shinymaterialradioempty_"
+  selected <- if (is.null(selected)) choices[[1]] else as.character(selected)
+  if (length(selected) > 1) stop("The 'selected' argument must be of length 1")
+  if (! selected %in% choices) stop("The 'selected' argument must be in choices")
   
   for(i in 1:length(choices)){
     material_radio_choices[[i]] <-
       shiny::tags$p(
         shiny::tags$input(
+          class = if (with_gap) "with-gap",
           type = "radio",
           name = input_id,
-          class = 
-            ifelse(
-              is.null(color),
-              '', 
-              paste0('shinymaterial-radio-button-', input_id)
-            ),
-          id = ifelse(choices[i] != "", choices[i], "_shinymaterialradioempty_")
+          class = if (!is.null(color)) 
+            paste0('shinymaterial-radio-button-', input_id),
+          id = choices[i],
+          checked = if(choices[i] %in% selected) "checked"
         ),
         shiny::tags$label(
-          `for` = ifelse(choices[i] != "", choices[i], "_shinymaterialradioempty_"),
-          ifelse(
-            has_names,
-            names(choices[i]),
-            choices[i]
-          )
+          `for` = choices[i],
+          ifelse(has_names, names(choices[i]), choices[i])
         )
       )
   }

--- a/inst/js/shiny-material-radio-button.js
+++ b/inst/js/shiny-material-radio-button.js
@@ -20,6 +20,4 @@ $(document).ready(function () {
 
     Shiny.inputBindings.register(shinyMaterialRadioButton);
 
-    $(".shiny-material-radio-button").find("input:first").trigger("click");
-
 });

--- a/man/material_radio_button.Rd
+++ b/man/material_radio_button.Rd
@@ -4,7 +4,8 @@
 \alias{material_radio_button}
 \title{Create a shinymaterial radio button}
 \usage{
-material_radio_button(input_id, label, choices, color = NULL)
+material_radio_button(input_id, label, choices, selected = NULL,
+  color = NULL, with_gap = FALSE)
 }
 \arguments{
 \item{input_id}{String. The input identifier used to access the value.}
@@ -13,7 +14,11 @@ material_radio_button(input_id, label, choices, color = NULL)
 
 \item{choices}{Named vector. The option names and underyling values.}
 
+\item{selected}{The initially selected value (if not specified then defaults to the first value).}
+
 \item{color}{String. The color of the radio buttons. Leave empty for the default color. Visit \url{http://materializecss.com/color.html} for a list of available colors. \emph{This input requires using color hex codes, rather than the word form. E.g., "#ef5350", rather than "red lighten-1".}}
+
+\item{with_gap}{Boolean. To create a radio button with a gap.}
 }
 \description{
 Build a shinymaterial radio button.


### PR DESCRIPTION
Hi Eric & package users, 

I propose to answer issue #74 with this PR.
I also add the class option `with-gap` present into the materialize library. It's only affect the style.

### Changes :

* New params for function  `material_radio_button` :
  * `selected` : The initially selected value (if not specified then defaults to the first value).
  * `with_gap` : To create a radio button with a gap.
* Update documentation file
* Suppress JS code setting the first option - made it in R function. 

### Test :

```R
rm(list = ls())
library(shiny)
library(shinymaterial)

ui <- material_page(
  title = "Basic Page",
  material_radio_button(
    input_id = "test",
    label = "label", 
    choices = c("One", "Two", "Three"),
    selected = "Three",
    with_gap = T
  )
)

server <- function(input, output) {}

shinyApp(ui = ui, server = server)
```

Best regards.