### PR TITLE
Update_material_button : patch minor bug (enable => disabled)

### DIFF
--- a/R/update-shiny-material-button.R
+++ b/R/update-shiny-material-button.R
@@ -20,7 +20,7 @@
 #' }
 update_material_button <- function (session, input_id, label = NULL, icon = NULL, enable = TRUE) {
   
-  js_code <- paste0("$('#", input_id, "').prop( 'disabled', ", tolower(enable), " )")
+  js_code <- paste0("$('#", input_id, "').prop( 'disabled', ", tolower(!enable), " )")
   session$sendCustomMessage(type = "shinymaterialJS", js_code)
   
   if (!is.null(label)){

--- a/R/update-shiny-material-button.R
+++ b/R/update-shiny-material-button.R
@@ -6,7 +6,7 @@
 #' @param input_id The input_id of the material_button.
 #' @param label The new label of the material_button.
 #' @param icon The new icon of the material_button. If not set, icon disappear.
-#' @param enable TRUE if the button is enable, FALSE if disable.  
+#' @param disabled NULL by default (do nothing), if TRUE the button is disable and if FALSE, enable.
 #' @seealso \code{\link{material_button}}
 #' @examples
 #' \dontrun{
@@ -15,13 +15,15 @@
 #'   input_id = "example_button",
 #'   value = "New Text",
 #'   icon = "stop",
-#'   enable = FALSE
+#'   disabled = FALSE
 #' )
 #' }
-update_material_button <- function (session, input_id, label = NULL, icon = NULL, enable = TRUE) {
+update_material_button <- function (session, input_id, label = NULL, icon = NULL, disabled = NULL) {
   
-  js_code <- paste0("$('#", input_id, "').prop( 'disabled', ", tolower(!enable), " )")
-  session$sendCustomMessage(type = "shinymaterialJS", js_code)
+  if(!is.null(disabled)){
+    js_code <- paste0("$('#", input_id, "').prop( 'disabled', ", tolower(disabled), " )")
+    session$sendCustomMessage(type = "shinymaterialJS", js_code)
+  }
   
   if (!is.null(label)){
     if (!is.null(icon))

--- a/man/update_material_button.Rd
+++ b/man/update_material_button.Rd
@@ -4,8 +4,13 @@
 \alias{update_material_button}
 \title{Change the text, icon of a material_button on the client. Allow to disable.}
 \usage{
-update_material_button(session, input_id, label = NULL, icon = NULL,
-  enable = TRUE)
+update_material_button(
+  session,
+  input_id,
+  label = NULL,
+  icon = NULL,
+  disabled = NULL
+)
 }
 \arguments{
 \item{session}{The session object passed to function given to shinyServer.}
@@ -16,7 +21,7 @@ update_material_button(session, input_id, label = NULL, icon = NULL,
 
 \item{icon}{The new icon of the material_button. If not set, icon disappear.}
 
-\item{enable}{TRUE if the button is enable, FALSE if disable.}
+\item{disabled}{NULL by default (do nothing), if TRUE the button is disable and if FALSE, enable.}
 }
 \description{
 Change the value text, icon of a material_button on the client. 
@@ -29,7 +34,7 @@ update_material_button(
   input_id = "example_button",
   value = "New Text",
   icon = "stop",
-  enable = FALSE
+  disabled = FALSE
 )
 }
 }


### PR DESCRIPTION
Hi Eric, 

Just a minor patch for the function `update_material_button`; I forgot to inverse the boolean `enable`. The property for the js code is `disabled` and it's different from the R function (enable). 

Thanks. 
 